### PR TITLE
Revised UberMain

### DIFF
--- a/nucleus/common/simple-glassfish-api/src/main/java/org/glassfish/embeddable/GlassFishException.java
+++ b/nucleus/common/simple-glassfish-api/src/main/java/org/glassfish/embeddable/GlassFishException.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -22,6 +23,8 @@ package org.glassfish.embeddable;
  * @author prasad
  */
 public class GlassFishException extends Exception {
+
+    private static final long serialVersionUID = 5879674257983677584L;
 
     public GlassFishException(String message, Throwable cause) {
         super(message, cause);

--- a/nucleus/core/bootstrap-osgi/src/main/java/org/glassfish/main/boot/embedded/EmbeddedGlassFishRuntime.java
+++ b/nucleus/core/bootstrap-osgi/src/main/java/org/glassfish/main/boot/embedded/EmbeddedGlassFishRuntime.java
@@ -116,8 +116,8 @@ class EmbeddedGlassFishRuntime extends GlassFishRuntime {
         for (GlassFish glassFish : glassFishInstances.values()) {
             try {
                 glassFish.dispose();
-            } catch (IllegalStateException ex) {
-                LOG.log(FINER, "GlassFish dispose failed: " + ex.getMessage());
+            } catch (IllegalStateException e) {
+                LOG.log(FINER, "GlassFish dispose failed: " + e.getMessage(), e);
             }
         }
 
@@ -125,8 +125,8 @@ class EmbeddedGlassFishRuntime extends GlassFishRuntime {
 
         try {
             shutdownInternal();
-        } catch (GlassFishException ex) {
-            LOG.log(WARNING, LogFacade.CAUGHT_EXCEPTION, ex.getMessage());
+        } catch (GlassFishException e) {
+            LOG.log(WARNING, LogFacade.CAUGHT_EXCEPTION, e);
         }
     }
 

--- a/nucleus/core/bootstrap-osgi/src/main/java/org/glassfish/main/boot/embedded/EmbeddedGlassFishRuntimeBuilder.java
+++ b/nucleus/core/bootstrap-osgi/src/main/java/org/glassfish/main/boot/embedded/EmbeddedGlassFishRuntimeBuilder.java
@@ -123,8 +123,8 @@ public class EmbeddedGlassFishRuntimeBuilder implements RuntimeBuilder {
                 } else if (pathname.getName().endsWith(JAR_EXT) && !MODULE_EXCLUDES.contains(pathname.getName())) {
                     try {
                         moduleJarURLs.add(pathname.toURI().toURL());
-                    } catch (Exception ex) {
-                        LOG.log(Level.WARNING, LogFacade.CAUGHT_EXCEPTION, ex);
+                    } catch (Exception e) {
+                        LOG.log(Level.WARNING, LogFacade.CAUGHT_EXCEPTION, e);
                     }
                 }
                 return false;

--- a/nucleus/core/kernel/src/main/java/org/glassfish/runnablejar/commandline/Arguments.java
+++ b/nucleus/core/kernel/src/main/java/org/glassfish/runnablejar/commandline/Arguments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -57,11 +57,11 @@ public class Arguments {
     public final List<String> commands = new ArrayList<>();
     public final GlassFishProperties glassFishProperties = new GlassFishProperties();
     public final List<String> deployables = new ArrayList<>();
-    public boolean askedForHelp = false;
-    public boolean noInfo = false;
-    public boolean shutdown = false;
-    public boolean prompt = false;
-    private String argumentsDocList = null;
+    public boolean askedForHelp;
+    public boolean noInfo;
+    public boolean shutdown;
+    public boolean prompt;
+    private String argumentsDocList;
 
     public void setDefaults() {
         glassFishProperties.setPort(DEFAULT_HTTP_LISTENER, 8080);


### PR DESCRIPTION
- Better handling of System.exit and the goodbye message
- Processing errors to error codes (TODO: extend)
- enums processed completely
- Using System.console instead of STDIN for prompt
- Minimalized shutdown hook
- UberMain is now AutoCloseable, however main doesn't stop it - its purpose is to start it and return. However the class can be extended and used in any application.
- goodbye message can be null - anything can initiate exit for any reason.
- JdbcRuntimeExtension was printing logs on stdout